### PR TITLE
Added the ability to use Tasker variables as arguments for scripts.

### DIFF
--- a/app/src/main/java/com/termux/tasker/FireReceiver.java
+++ b/app/src/main/java/com/termux/tasker/FireReceiver.java
@@ -9,6 +9,10 @@ import android.util.Log;
 import android.widget.Toast;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * This is the "fire" BroadcastReceiver for a Locale Plug-in.
@@ -31,7 +35,13 @@ public final class FireReceiver extends BroadcastReceiver {
         if (!PluginBundleManager.isBundleValid(bundle)) return;
 
         final String executable = bundle.getString(PluginBundleManager.EXTRA_EXECUTABLE);
+        final String arguments = bundle.getString(PluginBundleManager.EXTRA_ARGUMENTS);
         final boolean inTerminal = bundle.getBoolean(PluginBundleManager.EXTRA_TERMINAL);
+        Matcher matcher = Pattern.compile("([^\"]\\S*|\".+?\")\\s*").matcher(arguments);
+        List<String> list = new ArrayList<String>();
+        while (matcher.find()){
+            list.add(matcher.group(1).replace("\"",""));
+        }
 
         File executableFile = new File(EditConfigurationActivity.TASKER_DIR, executable);
         if (!executableFile.isFile()) {
@@ -47,6 +57,7 @@ public final class FireReceiver extends BroadcastReceiver {
         Intent executeIntent = new Intent(ACTION_EXECUTE, scriptUri);
         executeIntent.setClassName("com.termux", TERMUX_SERVICE);
         if (!inTerminal) executeIntent.putExtra("com.termux.execute.background", true);
+        executeIntent.putExtra(PluginBundleManager.EXTRA_ARGUMENTS, list.toArray(new String[list.size()]));
         context.startService(executeIntent);
     }
 

--- a/app/src/main/java/com/termux/tasker/PluginBundleManager.java
+++ b/app/src/main/java/com/termux/tasker/PluginBundleManager.java
@@ -11,6 +11,13 @@ import android.util.Log;
 final class PluginBundleManager {
 
     /**
+     * Type: {@code sting}.
+     *
+     * The arguments to pass to the script.
+     */
+    public static final String EXTRA_ARGUMENTS = "com.termux.execute.arguments";
+
+    /**
      * Type: {@code String}.
      *
      * The path to the executable to execute.
@@ -51,6 +58,11 @@ final class PluginBundleManager {
             return false;
         }
 
+        if (!bundle.containsKey(EXTRA_ARGUMENTS)) {
+            Log.e(Constants.LOG_TAG, String.format("bundle must contain extra %s", EXTRA_ARGUMENTS));
+            return false;
+        }
+
         if (!bundle.containsKey(BUNDLE_EXTRA_INT_VERSION_CODE)) {
             Log.e(Constants.LOG_TAG, String.format("bundle must contain extra %s", BUNDLE_EXTRA_INT_VERSION_CODE));
             return false;
@@ -61,8 +73,11 @@ final class PluginBundleManager {
          * extras above so that the error message is more useful. (E.g. the caller will see what extras are
          * missing, rather than just a message that there is the wrong number).
          */
-        if (3 != bundle.keySet().size()) {
-            Log.e(Constants.LOG_TAG, String.format("bundle must contain 3 keys, but currently contains %d keys", bundle.keySet().size()));
+        if (4 != bundle.keySet().size()) {
+            if (bundle.containsKey("net.dinglisch.android.tasker.extras.VARIABLE_REPLACE_KEYS")){
+                return true;
+            }
+            Log.e(Constants.LOG_TAG, String.format("bundle must contain 4 keys, but currently contains %d keys", bundle.keySet().size()));
             return false;
         }
 
@@ -79,9 +94,10 @@ final class PluginBundleManager {
         return true;
     }
 
-    public static Bundle generateBundle(final Context context, final String executable, final boolean inTerminal) {
+    public static Bundle generateBundle(final Context context, final String executable, final String arguments, final boolean inTerminal) {
         final Bundle result = new Bundle();
         result.putInt(BUNDLE_EXTRA_INT_VERSION_CODE, Constants.getVersionCode(context));
+        result.putString(EXTRA_ARGUMENTS,arguments);
         result.putString(EXTRA_EXECUTABLE, executable);
         result.putBoolean(EXTRA_TERMINAL, inTerminal);
         return result;

--- a/app/src/main/res/layout/edit_activity.xml
+++ b/app/src/main/res/layout/edit_activity.xml
@@ -25,14 +25,25 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"/>
     </android.support.design.widget.TextInputLayout>
-
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/argument_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <EditText
+            android:id="@+id/arguments"
+            android:paddingBottom="@dimen/activity_vertical_margin"
+            android:paddingTop="@dimen/activity_vertical_margin"
+            android:hint="@string/arguments_hint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </android.support.design.widget.TextInputLayout>
     <CheckBox
         android:id="@+id/in_terminal"
-        android:paddingBottom="@dimen/activity_vertical_margin"
-        android:paddingTop="@dimen/activity_vertical_margin"
-
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
         android:text="@string/execute_in_terminal" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,13 +11,14 @@
     <string name="no_tasker_folder_title">No ~/.termux/tasker/ directory</string>
     <string name="no_tasker_folder_message">You need to create a ~/.termux/tasker/ directory containing scripts to be executed.</string>
 
-    <string name="blurb_in_background">Execute ~/.termux/tasker/%s.</string>
-    <string name="blurb_in_terminal">Execute ~/.termux/tasker/%s in a terminal session.</string>
+    <string name="blurb_in_background">Execute ~/.termux/tasker/%1$s %2$s</string>
+    <string name="blurb_in_terminal">Execute ~/.termux/tasker/%1$s %2$s in a terminal session.</string>
 
     <!-- From Tasker API: -->
     <string name="twofortyfouram_locale_breadcrumb_format" tools:ignore="UnusedResources">%1$s%2$s%3$s</string>
     <string name="twofortyfouram_locale_breadcrumb_separator" tools:ignore="UnusedResources">\u0020&gt;\u0020</string>
     <string name="twofortyfouram_locale_menu_dontsave">Cancel</string>
     <string name="twofortyfouram_locale_menu_save">Done</string>
+    <string name="arguments_hint">Arguments</string>
 
 </resources>


### PR DESCRIPTION
I added the ability to use Tasker variables as parameters for Termux scripts. From my point of view, everything works as expected. The arguments are stored as a simple string and converted to a String Array when the plugin receives a fire intent. Quoted strings are kept together, while the arguments are splitted on spaces. This way you can just write the commands as you would in a shell.
Using Tasker variables works, though one has to type them manually in the configuration dialog.
It would be great if this could be part of the official app, since using an own build will interfere with the main apps package signature and thus would require to also build Termux. This way you can't benefit from PlayStore updates to the official main app.