### PR TITLE
Set the output of %stdout %stderr and %result from executed tasks

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
             </intent-filter>
         </receiver>
 
+        <service android:name=".ResultsService" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/termux/tasker/EditConfigurationActivity.java
+++ b/app/src/main/java/com/termux/tasker/EditConfigurationActivity.java
@@ -134,6 +134,31 @@ public final class EditConfigurationActivity extends AbstractPluginActivity {
 
                 resultIntent.putExtra(com.twofortyfouram.locale.Intent.EXTRA_BUNDLE, resultBundle);
                 resultIntent.putExtra(com.twofortyfouram.locale.Intent.EXTRA_STRING_BLURB, blurb);
+
+                // Configuration information for Tasker variables returned from the executed task
+                //
+                // Not run if we are opening a terminal because the user might not care about this
+                // if they are running something that will literally pop up in front of them (Plus
+                // getting that information requires additional work for now)
+                if(!inTerminal) {
+                    if (TaskerPlugin.hostSupportsRelevantVariables(getIntent().getExtras())) {
+                        TaskerPlugin.addRelevantVariableList(resultIntent, new String[]{
+                                "%stdout\nStandard Output\nThe <B>output</B> of running the command",
+                                "%stderr\nStandard Error\nThe <B>error output</B> of running the command",
+                                "%result\nExit Code\nThe exit code set by the command upon completion.\n" +
+                                        "0 often means success and anything else is usually a failure of some sort"
+                        });
+                    }
+
+                    // To use variables, we can't have a timeout of 0, but if someone doesn't pay
+                    // attention to this and runs a task that never ends, 10 seconds seems like a
+                    // reasonable timeout. If they need more time, or want this to run entirely
+                    // asynchronously, that can be set
+                    if (TaskerPlugin.Setting.hostSupportsSynchronousExecution(getIntent().getExtras())) {
+                        TaskerPlugin.Setting.requestTimeoutMS(resultIntent, 10000);
+                    }
+                }
+
                 setResult(RESULT_OK, resultIntent);
             }
         }

--- a/app/src/main/java/com/termux/tasker/ResultsService.java
+++ b/app/src/main/java/com/termux/tasker/ResultsService.java
@@ -1,0 +1,33 @@
+package com.termux.tasker;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+
+/**
+ * A service to handle the results sent back from Termux-app when it finishes executing a command we
+ * want to set Tasker variables with
+ *
+ * Expects an "originalIntent" ParcelableExtra containing the original {@link Intent} (Sent with the
+ * {@link android.app.PendingIntent} from the {@link FireReceiver}) and a {@link Bundle} object extra
+ * at "result" containing the keys "stdout" (String), "stderr" (String), and "exitCode" (Integer).
+ */
+public class ResultsService extends IntentService {
+    public ResultsService(){
+        super("ResultsService");
+    }
+
+    @Override
+    protected void onHandleIntent(@Nullable Intent intent) {
+        final Bundle result = intent.getBundleExtra("result");
+        final Intent originalIntent = intent.getParcelableExtra(FireReceiver.ORIGINAL_INTENT);
+        final Bundle varsBundle = new Bundle();
+
+        varsBundle.putString("%stdout", result.getString("stdout", ""));
+        varsBundle.putString("%stderr", result.getString("stderr", ""));
+        varsBundle.putString("%result", Integer.toString(result.getInt("exitCode")));
+
+        TaskerPlugin.Setting.signalFinish(this, originalIntent, TaskerPlugin.Setting.RESULT_CODE_OK, varsBundle);
+    }
+}


### PR DESCRIPTION
This pull request adds the ability to return data from [termux-app](https://github.com/termux/termux-app) using PendingIntents.

It uses them to set the executed process `%result`, `%stdout`, and `%stderr` for Tasker to use.

![nano, editing a script that will output to stdout, stderr, and exit with a status of 20](https://user-images.githubusercontent.com/1385527/69950697-10180d00-14b1-11ea-96f0-b61de47b7ce3.png)

![The Tasker configuration screen showing that there are three variables that will be set, %stdout, %stderr, and %result](https://user-images.githubusercontent.com/1385527/69950750-2d4cdb80-14b1-11ea-9e96-0ce8a93f6d56.png)

![A notification from Tasker showing the stdout, the stderr, and the exit status of 20](https://user-images.githubusercontent.com/1385527/69950798-3fc71500-14b1-11ea-9ac5-dcf7afebe4ea.png)

(This pull request requires the changes in [this pull request in the main app](https://github.com/termux/termux-app/pull/1365) to function properly and solves [this issue](https://github.com/termux/termux-tasker/issues/21).)