### PR TITLE
Don't try to perform variable substitution on a Boolean setting

### DIFF
--- a/app/src/main/java/com/termux/tasker/EditConfigurationActivity.java
+++ b/app/src/main/java/com/termux/tasker/EditConfigurationActivity.java
@@ -128,8 +128,10 @@ public final class EditConfigurationActivity extends AbstractPluginActivity {
                 // The blurb is a concise status text to be displayed in the host's UI.
                 final String blurb = generateBlurb(executable, arguments, inTerminal);
                 if (TaskerPlugin.Setting.hostSupportsOnFireVariableReplacement(this)){
-                    TaskerPlugin.Setting.setVariableReplaceKeys(resultBundle,new String[] {PluginBundleManager.EXTRA_EXECUTABLE,
-                            PluginBundleManager.EXTRA_ARGUMENTS,PluginBundleManager.EXTRA_TERMINAL});
+                    TaskerPlugin.Setting.setVariableReplaceKeys(resultBundle,new String[] {
+                            PluginBundleManager.EXTRA_EXECUTABLE,
+                            PluginBundleManager.EXTRA_ARGUMENTS
+                    });
                 }
 
                 resultIntent.putExtra(com.twofortyfouram.locale.Intent.EXTRA_BUNDLE, resultBundle);


### PR DESCRIPTION
One of the things that has been set as a variable replace key is `com.termux.tasker.extra.TERMINAL`, which is a boolean variable. This makes Tasker unhappy, and it yells about it in Logcat like so:

```
2019-12-02 02:12:13.492 9826-30816/net.dinglisch.android.taskerm E/Tasker: 02.12.13#b#ActionArgBundle: error: Termux: replace specified for null or non-string extra: com.termux.tasker.extra.TERMINAL
```

This pull request removes it from the list of things that termux-tasker attempts to perform string substitution on.