### PR TITLE
Updated Tasker URL due to change of project owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Join the chat at https://gitter.im/termux/termux](https://badges.gitter.im/termux/termux.svg)](https://gitter.im/termux/termux)
 
 A [Termux](https://termux.com) add-on app allowing Termux programs to be executed
-from [Tasker](https://tasker.dinglisch.net/).
+from [Tasker](https://tasker.joaoapps.com/).
 
 ## Installation
 


### PR DESCRIPTION
According to https://groups.google.com/forum/#!topic/tasker/SkCtZxnts4Y%5B1-25%5D ownership of Tasker changed back in 2018.
The website that was currently listed now shows an open dir and is served with an incorrect SSL cert for petroleumclub dot net instead.

Based on the Play Store page, it seems that https://tasker.joaoapps.com/ is now the current home for Tasker.